### PR TITLE
Add support for stackdriver backend

### DIFF
--- a/files/statsd-wrapper
+++ b/files/statsd-wrapper
@@ -10,7 +10,7 @@ CONFIGFILE=$2
 LOGFILE=$3
 
 
-NODE=$(which nodejs || which node)
+NODE=$(which nodejs 2>/dev/null|| which node 2>/dev/null)
 
 if ! [ -x "$NODE" ]; then
   echo "Unable to run node  '${NODE}' cannot be executed" >&2

--- a/manifests/backends.pp
+++ b/manifests/backends.pp
@@ -19,4 +19,15 @@ class statsd::backends {
       require => Package['statsd'],
     }
   }
+
+  # If we have a stackdriver API key, install the proper backend
+  if $statsd::stackdriver_apiKey {
+    exec { 'install-statsd-stackdriver-backend':
+      command => '/usr/bin/npm install --save stackdriver-statsd-backend',
+      cwd     => "${statsd::node_module_dir}/statsd",
+      unless  => "/usr/bin/test -d ${statsd::node_module_dir}/statsd/node_modules/stackdriver-statsd-backend",
+      require => Package['statsd'],
+    }
+  }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,13 +38,23 @@ class statsd (
   $librato_retryDelaySecs       = $statsd::params::librato_retryDelaySecs,
   $librato_postTimeoutSecs      = $statsd::params::librato_postTimeoutSecs,
 
+  $stackdriver_apiKey           = $statsd::params::stackdriver_apiKey,
+  $stackdriver_source           = $statsd::params::stackdriver_source,
+  $stackdriver_debug            = $statsd::params::stackdriver_debug,
+
   $config                       = $statsd::params::config,
 
   $init_location                = $statsd::params::init_location,
   $init_mode                    = $statsd::params::init_mode,
   $init_provider                = $statsd::params::init_provider,
   $init_script                  = $statsd::params::init_script,
+
+  $dependencies                 = $statsd::params::dependencies,
 ) inherits statsd::params {
+
+  if $dependencies {
+    $dependencies -> Class['statsd']
+  }
 
   class { 'statsd::backends': }
   class { 'statsd::config': }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,7 +38,13 @@ class statsd::params {
   $librato_retryDelaySecs       = '5'
   $librato_postTimeoutSecs      = '4'
 
+  $stackdriver_apiKey           = undef
+  $stackdriver_source           = undef
+  $stackdriver_debug            = false
+
   $config                       = { }
+
+  $dependencies                 = undef
 
   case $::osfamily {
     'RedHat', 'Amazon': {

--- a/templates/localConfig.js.erb
+++ b/templates/localConfig.js.erb
@@ -4,8 +4,10 @@
 , backends: [<% @backends.each do |backend| -%>
   "<%= backend %>",
   <% end -%>]
+<% if @backends.grep(/.*graphite$/).any? -%>
 , graphitePort: "<%= @graphitePort %>"
 , graphiteHost: "<%= @graphiteHost %>"
+<% end -%>
 
 , debug: <%= @debug %>
 , mgmt_address: "<%= @mgmt_address %>"
@@ -44,6 +46,18 @@
     skipInternalMetrics: "<%= @librato_skipInternalMetrics %>",
     retryDelaySecs: "<%= @librato_retryDelaySecs %>",
     postTimeoutSecs: "<%= @librato_postTimeoutSecs %>"
+  }
+<% end -%>
+<% if @stackdriver_apiKey -%>
+
+, stackdriver: {
+    apiKey: "<%= @stackdriver_apiKey %>",
+<% if @stackdriver_source -%>
+    source: "<%= @stackdriver_source %>",
+<% end -%>
+<% if @stackdriver_debug -%>
+    debug: "true"
+<% end -%>
   }
 <% end -%>
 <% @config.each do |k, v| -%>


### PR DESCRIPTION
- Adds support for the stackdriver backend.
- Provides for dependency resolution: optional $dependencies arg may include 1 or more resources which should be applied before the statsd module; for example to allow for a npm provider which would be found in another module which must be loaded first.
- Only load graphite settings if the graphite backend is present.

This should be backwards compatible with existing installations.
