### PR TITLE
ignore undefined or empty graphite_globalSuffix

### DIFF
--- a/templates/localConfig.js.erb
+++ b/templates/localConfig.js.erb
@@ -25,7 +25,9 @@
     prefixTimer:      "<%= @graphite_prefixTimer %>",
     prefixGauge:      "<%= @graphite_prefixGauge %>",
     prefixSet:        "<%= @graphite_prefixSet %>",
+  <% if defined? @graphite_globalSuffix and @graphite_globalSuffix != "" -%>
     globalSuffix:     "<%= @graphite_globalSuffix %>"
+  <% end -%>
   }
 <% end -%>
 


### PR DESCRIPTION
I think this is a fix for pull request #3 that was recently merged. I found that the default value for Graphite's global suffix (empty string) resulted in .wsp files without a name. For example, I'd have stats written to /opt/graphite/storage/whisper/stats/counters/foo/.wsp instead of foo.wsp.
