### PR TITLE
correct capitalization of flushInterval

### DIFF
--- a/templates/localConfig.js.erb
+++ b/templates/localConfig.js.erb
@@ -11,7 +11,7 @@
 , title: "<%= @statsd_title %>"
 , healthStatus: "<%= @healthStatus %>"
 , dumpMessages: <%= @dumpMessages %>
-, flushinterval: "<%= @flushInterval %>"
+, flushInterval: "<%= @flushInterval %>"
 , percentThreshold: [<%= @percentThreshold.join(', ') %>]
 , flush_counts: <%= @flush_counts %>
 


### PR DESCRIPTION
The statds config template contained "flushinterval" instead of "flushInterval", so statsd would silently use the default value of 10000 instead of whatever was set by the user.
