### PR TITLE
Correct init_provider variable name for statsd service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,7 +78,7 @@ class statsd (
     ensure    => running,
     enable    => true,
     hasstatus => true,
-    provider  => $statsd::params::init_provider,
+    provider  => $init_provider,
     require   => [ Package['statsd'], File['/var/log/statsd'] ],
   }
 }


### PR DESCRIPTION
This properly allows the init_provider statsd class parameter to override the default service provider that's set in the params class.
