### PR TITLE
Small patch to allow one to override the nodejs binary path

### DIFF
--- a/files/statsd-upstart
+++ b/files/statsd-upstart
@@ -14,5 +14,5 @@ respawn limit 10 5
 
 script
     . /etc/default/statsd
-    exec /usr/bin/node $STATSJS $STATSD_CONFIG >> $STATSD_LOGFILE
+    exec $NODEJS $STATSJS $STATSD_CONFIG >> $STATSD_LOGFILE
 end script

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,8 +1,10 @@
 # == Class: statsd::config
-class statsd::config {
-  $configfile  = '/etc/statsd/localConfig.js'
-  $logfile     = '/var/log/statsd/statsd.log'
-  $statsjs = "${statsd::node_module_dir}/statsd/stats.js"
+class statsd::config (
+  $configfile  = '/etc/statsd/localConfig.js',
+  $logfile     = '/var/log/statsd/statsd.log',
+  $statsjs     = "${statsd::node_module_dir}/statsd/stats.js",
+  $nodejs_bin  = $statsd::nodejs_bin
+) {
 
   file { '/etc/statsd':
     ensure => directory,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,6 +2,7 @@
 class statsd (
   $ensure                            = $statsd::params::ensure,
   $node_module_dir                   = $statsd::params::node_module_dir,
+  $nodejs_bin                        = $statsd::params::nodejs_bin,
 
   $port                              = $statsd::params::port,
   $address                           = $statsd::params::address,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,6 +2,7 @@
 class statsd::params {
   $ensure                            = 'present'
   $node_module_dir                   = '/usr/lib/node_modules'
+  $nodejs_bin                        = '/usr/bin/node'
 
   $port                              = '8125'
   $address                           = '0.0.0.0'

--- a/templates/statsd-defaults.erb
+++ b/templates/statsd-defaults.erb
@@ -1,6 +1,7 @@
 # HEADER: This file is being managed by Puppet. Any manual changes to this file
 # will be overwritten.
 
+NODEJS="<%= @nodejs_bin %>"
 STATSJS="<%= @statsjs %>"
 STATSD_CONFIG="<%= @configfile %>"
 STATSD_LOGFILE="<%= @logfile %>"


### PR DESCRIPTION
The path in ubuntu 14.04 when using the default repo is /usr/bin/nodejs as appose to /usr/bin/node
