### PR TITLE
Run daemon as nobody:nogroup when starting via upstart

### DIFF
--- a/files/statsd-upstart
+++ b/files/statsd-upstart
@@ -12,6 +12,9 @@ start on (local-filesystems and net-device-up IFACE!=lo)
 respawn
 respawn limit 10 5
 
+setuid nobody
+setgid nogroup
+
 script
     . /etc/default/statsd
     exec $NODEJS $STATSJS $STATSD_CONFIG >> $STATSD_LOGFILE


### PR DESCRIPTION
Run the statsd daemon as nobody:nogroup on ubuntu.
