### PR TITLE
Adding ability to disable statsd service and prevent it starting on boot

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,9 @@ class statsd (
   $address                           = $statsd::params::address,
   $configfile                        = $statsd::params::configfile,
 
+  $service_ensure                    = $statsd::params::service_ensure, 
+  $service_enable                    = $statsd::params::service_enable, 
+
   $backends                          = $statsd::params::backends,
   $debug                             = $statsd::params::debug,
   $mgmt_address                      = $statsd::params::mgmt_address,
@@ -81,8 +84,8 @@ class statsd (
   }
 
   service { 'statsd':
-    ensure    => running,
-    enable    => true,
+    ensure    => $service_ensure,
+    enable    => $service_enable,
     hasstatus => true,
     provider  => $init_provider,
     require   => [ Package['statsd'], File['/var/log/statsd'] ],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,9 @@ class statsd::params {
   $address                           = '0.0.0.0'
   $configfile                        = '/etc/statsd/localConfig.js'
 
+  $service_ensure                    = 'running'
+  $service_enable                    = true
+
   $backends                          = [ './backends/graphite' ]
   $debug                             = false
   $mgmt_address                      = '0.0.0.0'

--- a/spec/classes/statsd_spec.rb
+++ b/spec/classes/statsd_spec.rb
@@ -14,6 +14,7 @@ describe 'statsd', :type => :class do
       it { should contain_statsd__config }
       it { should contain_package('statsd').with_ensure('present') }
       it { should contain_service('statsd').with_ensure('running') }
+      it { should contain_service('statsd').with_enable(true) }
 
       it { should contain_file('/etc/statsd') }
       it { should contain_file('/etc/statsd/localConfig.js') }
@@ -27,6 +28,20 @@ describe 'statsd', :type => :class do
 
       if osfamily == 'RedHat'
         it { should contain_file('/etc/init.d/statsd') }
+      end
+
+      describe 'stopping the statsd service' do
+	let(:params) {{
+	  :service_ensure => 'stopped',
+        }}
+        it { should contain_service('statsd').with_ensure('stopped') }
+      end
+
+      describe 'disabling the statsd service' do
+	let(:params) {{
+	  :service_enable => false,
+        }}
+        it { should contain_service('statsd').with_enable(false) }
       end
     end
   end


### PR DESCRIPTION
Useful for if running in a container (such as Docker) as the statsd service will run in the foreground instead.