### PR TITLE
Allowing the disabling of the service entirely

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,7 +39,10 @@ class statsd::config (
   File {
     owner  => 'root',
     group  => 'root',
-    notify => Service['statsd'],
+  }
+
+  if $statsd::manage_service == true {
+    File <| |> ~> Service['statsd']
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@ class statsd (
   $address                           = $statsd::params::address,
   $configfile                        = $statsd::params::configfile,
 
+  $manage_service                    = $statsd::params::manage_service, 
   $service_ensure                    = $statsd::params::service_ensure, 
   $service_enable                    = $statsd::params::service_enable, 
 
@@ -83,11 +84,13 @@ class statsd (
     provider => $package_provider,
   }
 
-  service { 'statsd':
-    ensure    => $service_ensure,
-    enable    => $service_enable,
-    hasstatus => true,
-    provider  => $init_provider,
-    require   => [ Package['statsd'], File['/var/log/statsd'] ],
+  if $manage_service == true {
+    service { 'statsd':
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      hasstatus => true,
+      provider  => $init_provider,
+      require   => [ Package['statsd'], File['/var/log/statsd'] ],
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class statsd::params {
   $address                           = '0.0.0.0'
   $configfile                        = '/etc/statsd/localConfig.js'
 
+  $manage_service                    = true
   $service_ensure                    = 'running'
   $service_enable                    = true
 

--- a/spec/classes/statsd_spec.rb
+++ b/spec/classes/statsd_spec.rb
@@ -43,6 +43,13 @@ describe 'statsd', :type => :class do
         }}
         it { should contain_service('statsd').with_enable(false) }
       end
+
+      describe 'disabling the management of the statsd service' do
+	let(:params) {{
+	  :manage_service => false,
+        }}
+        it { should_not contain_service('statsd') }
+      end
     end
   end
 


### PR DESCRIPTION
Useful for RHEL7 docker containers which use fakesystemd which prevents managing the service from working properly