### PR TITLE
Fix for default librato snapTime and default flushInterval

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class statsd::params {
   $statsd_title                      = 'statsd'
   $healthStatus                      = 'up'
   $dumpMessages                      = false
-  $flushInterval                     = '10000'
+  $flushInterval                     = '10'
   $percentThreshold                  = ['90']
   $flush_counts                      = true
 
@@ -45,7 +45,7 @@ class statsd::params {
 
   $librato_email                     = undef
   $librato_token                     = undef
-  $librato_snapTime                  = '10000'
+  $librato_snapTime                  = '10'
   $librato_countersAsGauges          = true
   $librato_skipInternalMetrics       = true
   $librato_retryDelaySecs            = '5'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jdowning-statsd",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "source": "https://github.com/justindowning/puppet-statsd",
   "author": "Justin Downing",
   "license": "Apache-2.0",


### PR DESCRIPTION
It appears defaults were assumed to be in ms not seconds. Led to metrics being rejected by librato for being snapped to 2.7 hours ago and so outside of an acceptable time window. 10 recommended for both settings.