### PR TITLE
Fix bad file resource

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,40 +9,42 @@ class statsd::config (
   file { '/etc/statsd':
     ensure => directory,
     mode   => '0755',
+    owner  => 'root',
+    group  => 'root',
   }->
   file { $configfile:
     content => template('statsd/localConfig.js.erb'),
     mode    => '0644',
+    owner  => 'root',
+    group  => 'root',
   }
 
   file { $statsd::init_location:
     source => $statsd::init_script,
     mode   => $statsd::init_mode,
+    owner  => 'root',
+    group  => 'root',
   }
 
   file {  '/etc/default/statsd':
     content => template('statsd/statsd-defaults.erb'),
+    owner  => 'root',
+    group  => 'root',
     mode    => '0755',
   }
 
   file { '/var/log/statsd':
     ensure => directory,
-    owner  => 'nobody',
     mode   => '0755',
+    owner  => 'nobody',
+    group  => 'root',
   }
 
   file { '/usr/local/sbin/statsd':
     source => 'puppet:///modules/statsd/statsd-wrapper',
     mode   => '0755',
-  }
-
-  File {
     owner  => 'root',
     group  => 'root',
-  }
-
-  if $statsd::manage_service == true {
-    File <| |> ~> Service['statsd']
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -95,6 +95,7 @@ class statsd (
       enable    => $service_enable,
       hasstatus => true,
       provider  => $init_provider,
+      subscribe => Class['statsd::config'],
       require   => [ Package['statsd'], File['/var/log/statsd'] ],
     }
   }

--- a/templates/localConfig.js.erb
+++ b/templates/localConfig.js.erb
@@ -55,7 +55,7 @@
 , librato: {
     email: "<%= @librato_email %>",
     token: "<%= @librato_token %>",
-    source: "<% @librato_source %>",
+    source: "<%= @librato_source %>",
     snapTime: "<%= @librato_snapTime %>",
     countersAsGauges: <%= @librato_countersAsGauges %>,
     skipInternalMetrics: <%= @librato_skipInternalMetrics %>,


### PR DESCRIPTION
I ran into a problem where any class that required `Class['statsd']` would fall into a nasty resource loop if that class also managed file resources. This cleans that up.