### PR TITLE
Add $manage_backends parameter.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,13 +74,16 @@ class statsd (
   $package_provider                  = $statsd::params::package_provider,
 
   $dependencies                      = $statsd::params::dependencies,
+  $manage_backends                   = $statsd::params::manage_backends,
 ) inherits statsd::params {
 
   if $dependencies {
     $dependencies -> Class['statsd']
   }
 
-  class { 'statsd::backends': }
+  if $manage_backends {
+    class { 'statsd::backends': }
+  }
   class { 'statsd::config': }
 
   package { 'statsd':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -66,6 +66,7 @@ class statsd::params {
   $config                            = { }
 
   $dependencies                      = undef
+  $manage_backends                   = true
 
   $package_name                      = 'statsd'
   $package_provider                  = 'npm'


### PR DESCRIPTION
This adds a $manage_backends parameter that is used to determine if the
various supported statsd backend are managed by this class.  The default
value is 'true', and thus the default behavior is unchanged.  Setting
the value to 'false' will disable calling statsd::backends, and force
admins to manage the backends via other means.