### PR TITLE
Add support for deleteIdleStats et al

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,12 @@ class statsd (
   $percentThreshold                  = $statsd::params::percentThreshold,
   $flush_counts                      = $statsd::params::flush_counts,
 
+  $deleteIdleStats                   = $statsd::params::deleteIdleStats,
+  $deleteGauges                      = $statsd::params::deleteGauges,
+  $deleteTimers                      = $statsd::params::deleteTimers,
+  $deleteSets                        = $statsd::params::deleteSets,
+  $deleteCounters                    = $statsd::params::deleteCounters,
+
   $graphiteHost                      = $statsd::params::graphiteHost,
   $graphitePort                      = $statsd::params::graphitePort,
   $graphite_legacyNamespace          = $statsd::params::graphite_legacyNamespace,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,11 +25,11 @@ class statsd::params {
   $percentThreshold                  = ['90']
   $flush_counts                      = true
 
-  $deleteIdleStats                   = false
-  $deleteGauges                      = false
-  $deleteTimers                      = false
-  $deleteSets                        = false
-  $deleteCounters                    = false
+  $deleteIdleStats                   = undef
+  $deleteGauges                      = undef
+  $deleteTimers                      = undef
+  $deleteSets                        = undef
+  $deleteCounters                    = undef
 
   $graphiteHost                      = 'localhost'
   $graphitePort                      = '2003'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,12 @@ class statsd::params {
   $percentThreshold                  = ['90']
   $flush_counts                      = true
 
+  $deleteIdleStats                   = false
+  $deleteGauges                      = false
+  $deleteTimers                      = false
+  $deleteSets                        = false
+  $deleteCounters                    = false
+
   $graphiteHost                      = 'localhost'
   $graphitePort                      = '2003'
   $graphite_legacyNamespace          = true

--- a/templates/localConfig.js.erb
+++ b/templates/localConfig.js.erb
@@ -15,6 +15,12 @@
 , percentThreshold: [<%= @percentThreshold.join(', ') %>]
 , flush_counts: <%= @flush_counts %>
 
+, deleteIdleStats: <%= @deleteIdleStats %>
+, deleteGauges: <%= @deleteGauges %>
+, deleteTimers: <%= @deleteTimers %>
+, deleteSets: <%= @deleteSets %>
+, deleteCounters: <%= @deleteCounters %>
+
 <% if @backends.grep(/graphite/).any? -%>
 , graphitePort: "<%= @graphitePort %>"
 , graphiteHost: "<%= @graphiteHost %>"

--- a/templates/localConfig.js.erb
+++ b/templates/localConfig.js.erb
@@ -15,11 +15,21 @@
 , percentThreshold: [<%= @percentThreshold.join(', ') %>]
 , flush_counts: <%= @flush_counts %>
 
+<% if defined? @deleteIdleStats -%>
 , deleteIdleStats: <%= @deleteIdleStats %>
+<% end -%>
+<% if defined? @deleteGauges -%>
 , deleteGauges: <%= @deleteGauges %>
+<% end -%>
+<% if defined? @deleteTimers -%>
 , deleteTimers: <%= @deleteTimers %>
+<% end -%>
+<% if defined? @deleteSets -%>
 , deleteSets: <%= @deleteSets %>
+<% end -%>
+<% if defined? @deleteCounters -%>
 , deleteCounters: <%= @deleteCounters %>
+<% end -%>
 
 <% if @backends.grep(/graphite/).any? -%>
 , graphitePort: "<%= @graphitePort %>"


### PR DESCRIPTION
`deleteIdleStats` and related options control the pruning of different
metric types across flush intervals. The default behavior of statsd is
to "feed forward" counters and gauges it saw in the previous flush
interval which can cause unused metrics to accumulate in memory until
the daemon is restarted.

From the statsd [documentation](https://github.com/etsy/statsd/blob/master/exampleConfig.js):

>   deleteIdleStats:  don't send values to graphite for inactive counters, sets, gauges, or timers
                    as opposed to sending 0.  For gauges, this unsets the gauge (instead of sending
                    the previous value). Can be individually overriden. [default: false]

>  deleteGauges:     don't send values to graphite for inactive gauges, as opposed to sending the previous value [default: false]

>  deleteTimers:     don't send values to graphite for inactive timers, as opposed to sending 0 [default: false]

>  deleteSets:       don't send values to graphite for inactive sets, as opposed to sending 0 [default: false]

>  deleteCounters:   don't send values to graphite for inactive counters, as opposed to sending 0 [default: false]

This PR is to add those options as named parameters of the `statsd` type, rather than going through the generic `config` hash.