### PR TITLE
Add $environment parameter

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,7 +3,8 @@ class statsd::config (
   $configfile  = $statsd::configfile,
   $logfile     = $statsd::logfile,
   $statsjs     = "${statsd::node_module_dir}/statsd/stats.js",
-  $nodejs_bin  = $statsd::nodejs_bin
+  $nodejs_bin  = $statsd::nodejs_bin,
+  $environment = $statsd::environment
 ) {
 
   file { '/etc/statsd':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@ class statsd (
   $ensure                            = $statsd::params::ensure,
   $node_module_dir                   = $statsd::params::node_module_dir,
   $nodejs_bin                        = $statsd::params::nodejs_bin,
+  $environment                       = $statsd::params::environment,
 
   $port                              = $statsd::params::port,
   $address                           = $statsd::params::address,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,7 @@ class statsd::params {
   $ensure                            = 'present'
   $node_module_dir                   = '/usr/lib/node_modules'
   $nodejs_bin                        = '/usr/bin/node'
+  $environment                       = []
 
   $port                              = '8125'
   $address                           = '0.0.0.0'

--- a/templates/statsd-defaults.erb
+++ b/templates/statsd-defaults.erb
@@ -1,6 +1,9 @@
 # HEADER: This file is being managed by Puppet. Any manual changes to this file
 # will be overwritten.
 
+<% @environment.each do |val| -%>
+<%= val %>
+<% end -%>
 NODEJS="<%= @nodejs_bin %>"
 STATSJS="<%= @statsjs %>"
 STATSD_CONFIG="<%= @configfile %>"


### PR DESCRIPTION
Hi there, I submitted a similar PR to the [puppetlabs-operations/puppet-statsd](/puppetlabs-operations/puppet-statsd) repo, but it appears that repo is no longer maintained.  Also, it appears this this module is more mature. We use RHEL software collections for nodejs, so we have to custom set some environment variables.

 - Set the $environment to empty array
 - Reference the $environment in manifests/config.pp
 - For now, just set it in /etc/defaults/statsd