### PR TITLE
Update nodejs dependency

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,3 +6,5 @@ mod 'puppet/nodejs',
   :git => "git://github.com/puppet-community/puppet-nodejs.git"
 mod 'puppetlabs/stdlib',
   :git => "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+mod 'puppetlabs/apt',
+  :git => "git://github.com/puppetlabs/puppetlabs-apt.git"

--- a/Puppetfile
+++ b/Puppetfile
@@ -2,7 +2,7 @@ forge 'https://forgeapi.puppetlabs.com'
 
 mod 'stahnma/epel',
   :git => "git://github.com/stahnma/puppet-module-epel.git"
-mod 'puppetlabs/nodejs',
-  :git => "git://github.com/puppetlabs/puppetlabs-nodejs.git"
+mod 'puppet/nodejs',
+  :git => "git://github.com/puppet-community/puppet-nodejs.git"
 mod 'puppetlabs/stdlib',
   :git => "git://github.com/puppetlabs/puppetlabs-stdlib.git"

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -7,6 +7,14 @@ GIT
       puppetlabs-stdlib (< 5.0.0, >= 4.1.0)
 
 GIT
+  remote: git://github.com/puppetlabs/puppetlabs-apt.git
+  ref: master
+  sha: f05e43c28588a280a42333f9ca3a506a7121849d
+  specs:
+    puppetlabs-apt (2.1.1)
+      puppetlabs-stdlib (< 5.0.0, >= 4.5.0)
+
+GIT
   remote: git://github.com/puppetlabs/puppetlabs-stdlib.git
   ref: master
   sha: 79e79e8bbad5f3226b51fae5a2a64bc9a84031ae
@@ -22,6 +30,7 @@ GIT
 
 DEPENDENCIES
   puppet-nodejs (>= 0)
+  puppetlabs-apt (>= 0)
   puppetlabs-stdlib (>= 0)
   stahnma-epel (>= 0)
 

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,17 +1,10 @@
-FORGE
-  remote: https://forgeapi.puppetlabs.com
-  specs:
-    puppetlabs-apt (1.7.0)
-      puppetlabs-stdlib (>= 2.2.1)
-
 GIT
-  remote: git://github.com/puppetlabs/puppetlabs-nodejs.git
+  remote: git://github.com/puppet-community/puppet-nodejs.git
   ref: master
-  sha: 003933504245f1087c4c8cfcbc3d9b6097b228a1
+  sha: b9d2528fe37155388c57132ca213c5180a440f29
   specs:
-    puppetlabs-nodejs (0.6.1)
-      puppetlabs-apt (>= 0.0.3)
-      puppetlabs-stdlib (>= 2.0.0)
+    puppet-nodejs (1.1.0)
+      puppetlabs-stdlib (< 5.0.0, >= 4.1.0)
 
 GIT
   remote: git://github.com/puppetlabs/puppetlabs-stdlib.git
@@ -28,7 +21,7 @@ GIT
     stahnma-epel (1.0.2)
 
 DEPENDENCIES
-  puppetlabs-nodejs (>= 0)
+  puppet-nodejs (>= 0)
   puppetlabs-stdlib (>= 0)
   stahnma-epel (>= 0)
 

--- a/metadata.json
+++ b/metadata.json
@@ -10,6 +10,7 @@
   "source": "https://github.com/justindowning/puppet-statsd.git",
   "issues_url": "https://github.com/justindowning/puppet-statsd/issues",
   "dependencies": [
+    { "name": "puppetlabs/apt", "version_requirement": ">=1.0.0" },
     { "name": "puppetlabs/stdlib", "version_requirement": ">=4.1.0 <5.0.0" },
     { "name": "stahnma/epel", "version_requirement": ">1.0.0 <2.0.0" }
   ],

--- a/tests/vagrant/ubuntu.pp
+++ b/tests/vagrant/ubuntu.pp
@@ -1,4 +1,4 @@
-class { 'nodejs': manage_repo => true }->
+class { 'nodejs': manage_package_repo => true }->
 class { 'statsd':
   backends              => [
     './backends/graphite',


### PR DESCRIPTION
puppetlabs-nodejs has moved to [puppet-nodejs](https://github.com/puppet-community/puppet-nodejs), a puppet-community project. This PR accomplishes 2 goals:

1. Update the dependency on puppetlabs-nodejs (now defunct) in favor of puppet-nodejs which is the same codebase, but maintained by the open source puppet community.
2. puppet-nodejs removed its explicit dependency on apt, but still implicitly depends on it. This adds apt as an explicit dependency of puppet-statsd so the Vagrant environment will continue to function correctly.

Note: The choice of dependency on `puppetlabs-apt >= 1.0.0` is entirely arbitrary, and could just as easily be `puppetlabs-apt > 0` if so desired, since statsd doesn't actually require it for anything other than Vagrant. If you'd rather not make apt a dependency of puppet-statsd, we'll need to figure out a better way to provision test hosts in Vagrant (such as having a Vagrant-only Puppetfile).