### PR TITLE
Add support for built-in repeater backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You can install multiple backends. Supported backends include:
 * influxdb  
 * librato  
 * stackdriver  
+* repeater
 
 More information about the installation of each backend available in [manifests/backends.pp](https://github.com/justindowning/puppet-statsd/blob/master/manifests/backends.pp).
 
@@ -68,6 +69,16 @@ class { 'statsd':
 class { 'statsd':
   backends           => ['stackdriver-statsd-backend'],
   stackdriver_apiKey => 'apiKey'
+}
+```
+
+### Repeater
+
+```
+class { 'statsd':
+  backends         => ['./backends/repeater'],
+  repeater         => [{"host" => 'my.statsd.host', port => 8125}],
+  repeaterProtocol => 'udp4'
 }
 ```
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -55,6 +55,8 @@ class statsd::config (
   $stackdriver_sourcePrefixSeparator = $statsd::stackdriver_sourcePrefixSeparator,
   $stackdriver_sendTimerPercentiles  = $statsd::stackdriver_sendTimerPercentiles,
   $stackdriver_debug                 = $statsd::stackdriver_debug,
+  $repeater                          = $statsd::repeater,
+  $repeaterProtocol                  = $statsd::repeaterProtocol,
   $config                            = $statsd::config,
 
   $environment = $statsd::environment,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,6 +73,9 @@ class statsd (
   $stackdriver_sendTimerPercentiles  = $statsd::params::stackdriver_sendTimerPercentiles,
   $stackdriver_debug                 = $statsd::params::stackdriver_debug,
 
+  $repeater                          = $statsd::params::repeater,
+  $repeaterProtocol                  = $statsd::params::repeaterProtocol,
+
   $config                            = $statsd::params::config,
 
   $init_location                     = $statsd::params::init_location,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -73,6 +73,9 @@ class statsd::params {
   $stackdriver_sendTimerPercentiles  = false
   $stackdriver_debug                 = false
 
+  $repeater                          = undef
+  $repeaterProtocol                  = undef
+
   $config                            = { }
 
   $dependencies                      = undef

--- a/templates/localConfig.js.erb
+++ b/templates/localConfig.js.erb
@@ -96,6 +96,13 @@
   }
 <% end -%>
 
+<% if @backends.grep(/repeater/).any? -%>
+, repeater: [<%= @repeater.map { |r| r.to_json }.join(", ") %>]
+  <% if defined? @repeaterProtocol -%>
+, repeaterProtocol: <%= @repeaterProtocol %>
+  <% end -%>
+<% end -%>
+
 <% @config.each do |k, v| -%>
 , <%= k %>: <%= v %>
 <% end -%>

--- a/tests/vagrant/manifests/site.pp
+++ b/tests/vagrant/manifests/site.pp
@@ -9,11 +9,18 @@ class { 'statsd':
     './backends/graphite',
     'statsd-influxdb-backend',
     'statsd-librato-backend',
-    'stackdriver-statsd-backend'
+    'stackdriver-statsd-backend',
+    './backends/repeater'
   ],
   graphite_globalSuffix => 'foobar',
   influxdb_host         => 'localhost',
   librato_email         => 'foo@bar.com',
   librato_token         => 'secret_token',
-  stackdriver_apiKey    => 'foobar'
+  stackdriver_apiKey    => 'foobar',
+  repeater              => [
+    {
+      'host' => '1.1.1.1',
+      'port' => 8215
+    }
+  ]
 }


### PR DESCRIPTION
This change adds configuration support for the built-in `repeater` back end. Two new configuration options were added, `repeater` and `repeaterProtocol`, both of which are documented in the statsd source code configuration example here: https://github.com/etsy/statsd/blob/master/exampleConfig.js#L88

I also added support to the Vagrant test manifest but it wasn't clear how to properly run those tests. Let me know if I missed anything, or you would prefer me to implement something in an alternative way.

Thanks for making this module available.