### PR TITLE
add support for prefixStats config option

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,6 +13,7 @@ class statsd::config (
   $flushInterval                     = $statsd::flushInterval,
   $percentThreshold                  = $statsd::percentThreshold,
   $flush_counts                      = $statsd::flush_counts,
+  $prefix_stats                      = $statsd::prefix_stats,
   $deleteIdleStats                   = $statsd::deleteIdleStats,
   $deleteGauges                      = $statsd::deleteGauges,
   $deleteTimers                      = $statsd::deleteTimers,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,7 @@ class statsd (
   $flushInterval                     = $statsd::params::flushInterval,
   $percentThreshold                  = $statsd::params::percentThreshold,
   $flush_counts                      = $statsd::params::flush_counts,
+  $prefix_stats                      = $statsd::params::prefix_stats,
 
   $deleteIdleStats                   = $statsd::params::deleteIdleStats,
   $deleteGauges                      = $statsd::params::deleteGauges,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,7 @@ class statsd::params {
   $flushInterval                     = '10000'
   $percentThreshold                  = ['90']
   $flush_counts                      = true
+  $prefix_stats                      = 'statsd'
 
   $deleteIdleStats                   = undef
   $deleteGauges                      = undef

--- a/templates/localConfig.js.erb
+++ b/templates/localConfig.js.erb
@@ -14,6 +14,7 @@
 , flushInterval: "<%= @flushInterval %>"
 , percentThreshold: [<%= @percentThreshold.join(', ') %>]
 , flush_counts: <%= @flush_counts %>
+, prefixStats: <%= @prefix_stats %>
 
 <% if defined? @deleteIdleStats -%>
 , deleteIdleStats: <%= @deleteIdleStats %>

--- a/templates/localConfig.js.erb
+++ b/templates/localConfig.js.erb
@@ -14,7 +14,7 @@
 , flushInterval: "<%= @flushInterval %>"
 , percentThreshold: [<%= @percentThreshold.join(', ') %>]
 , flush_counts: <%= @flush_counts %>
-, prefixStats: <%= @prefix_stats %>
+, prefixStats: "<%= @prefix_stats %>"
 
 <% if defined? @deleteIdleStats -%>
 , deleteIdleStats: <%= @deleteIdleStats %>


### PR DESCRIPTION
as per the [statsd docs](https://github.com/etsy/statsd/blob/d7b31bf70da865a70f29d011b4e6d0b9f70f6ce1/exampleConfig.js#L62), the prefixStats config option allows you to customised the prefix used for internal statsd metrics (default: `statsd`)