### PR TITLE
allow option of setting influxdb package name

### DIFF
--- a/manifests/backends.pp
+++ b/manifests/backends.pp
@@ -6,7 +6,7 @@ class statsd::backends {
   # Make sure $statsd::influxdb_host is set
   if $backends =~ /influxdb/ {
     exec { 'install-statsd-influxdb-backend':
-      command => '/usr/bin/npm install --save statsd-influxdb-backend',
+      command => "/usr/bin/npm install --save ${statsd::influxdb_package_name}",
       cwd     => "${statsd::node_module_dir}/statsd",
       unless  => "/usr/bin/test -d ${node_base}/statsd-influxdb-backend",
       require => Package['statsd'],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,6 +27,7 @@ class statsd::config (
   $graphite_prefixGauge              = $statsd::graphite_prefixGauge,
   $graphite_prefixSet                = $statsd::graphite_prefixSet,
   $graphite_globalSuffix             = $statsd::graphite_globalSuffix,
+  $influxdb_package_name             = $statsd::influxdb_package_name,
   $influxdb_host                     = $statsd::influxdb_host,
   $influxdb_port                     = $statsd::influxdb_port,
   $influxdb_database                 = $statsd::influxdb_database,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,7 @@ class statsd (
   $graphite_prefixSet                = $statsd::params::graphite_prefixSet,
   $graphite_globalSuffix             = $statsd::params::graphite_globalSuffix,
 
+  $influxdb_package_name             = $statsd::params::influxdb_package_name,
   $influxdb_host                     = $statsd::params::influxdb_host,
   $influxdb_port                     = $statsd::params::influxdb_port,
   $influxdb_database                 = $statsd::params::influxdb_database,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,6 +42,7 @@ class statsd::params {
   $graphite_prefixSet                = 'sets'
   $graphite_globalSuffix             = undef
 
+  $influxdb_package_name             = 'statsd-influxdb-backend'
   $influxdb_host                     = undef
   $influxdb_port                     = '8086'
   $influxdb_database                 = 'statsd'


### PR DESCRIPTION
allows you to pass in a `git+https://` or `http://` target for npm install