### PR TITLE
allow option to specify package source

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,6 +84,7 @@ class statsd (
   $init_script                       = $statsd::params::init_script,
 
   $package_name                      = $statsd::params::package_name,
+  $package_source                    = $statsd::params::package_source,
   $package_provider                  = $statsd::params::package_provider,
 
   $dependencies                      = $statsd::params::dependencies,
@@ -102,6 +103,7 @@ class statsd (
     ensure   => $ensure,
     name     => $package_name,
     provider => $package_provider,
+    source   => $package_source
   }
 
   if $manage_service == true {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -81,6 +81,7 @@ class statsd::params {
   $dependencies                      = undef
 
   $package_name                      = 'statsd'
+  $package_source                    = undef
   $package_provider                  = 'npm'
 
   case $::osfamily {


### PR DESCRIPTION
useful if you want to install statsd from an alternative location (e.g. a github repo)