### PR TITLE
Remove hardcoded npm path

### DIFF
--- a/manifests/backends.pp
+++ b/manifests/backends.pp
@@ -6,7 +6,7 @@ class statsd::backends {
   # Make sure $statsd::influxdb_host is set
   if $backends =~ /influxdb/ {
     exec { 'install-statsd-influxdb-backend':
-      command => "/usr/bin/npm install --save ${statsd::influxdb_package_name}",
+      command => "${statsd::npm_bin} install --save ${statsd::influxdb_package_name}",
       cwd     => "${statsd::node_module_dir}/statsd",
       unless  => "/usr/bin/test -d ${node_base}/statsd-influxdb-backend",
       require => Package['statsd'],
@@ -16,7 +16,7 @@ class statsd::backends {
   # Make sure $statsd::librato_email and $statsd::librato_token are set
   if $backends =~ /librato/ {
     exec { 'install-statsd-librato-backend':
-      command => '/usr/bin/npm install --save statsd-librato-backend',
+      command => "${statsd::npm_bin} install --save statsd-librato-backend",
       cwd     => "${statsd::node_module_dir}/statsd",
       unless  => "/usr/bin/test -d ${node_base}/statsd-librato-backend",
       require => Package['statsd'],
@@ -26,7 +26,7 @@ class statsd::backends {
   # Make sure $statsd::stackdriver_apiKey is set
   if $backends =~ /stackdriver/ {
     exec { 'install-statsd-stackdriver-backend':
-      command => '/usr/bin/npm install --save stackdriver-statsd-backend',
+      command => "${statsd::npm_bin} install --save stackdriver-statsd-backend",
       cwd     => "${statsd::node_module_dir}/statsd",
       unless  => "/usr/bin/test -d ${node_base}/stackdriver-statsd-backend",
       require => Package['statsd'],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -66,6 +66,7 @@ class statsd::config (
 
   $environment = $statsd::environment,
   $nodejs_bin  = $statsd::nodejs_bin,
+  $npm_bin     = $statsd::npm_bin,
   $statsjs     = "${statsd::node_module_dir}/statsd/stats.js",
   $logfile     = $statsd::logfile,
 ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@ class statsd (
   $ensure                            = $statsd::params::ensure,
   $node_module_dir                   = $statsd::params::node_module_dir,
   $nodejs_bin                        = $statsd::params::nodejs_bin,
+  $npm_bin                           = $statsd::params::npm_bin,
   $environment                       = $statsd::params::environment,
 
   $port                              = $statsd::params::port,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,7 @@ class statsd::params {
   $ensure                            = 'present'
   $node_module_dir                   = '/usr/lib/node_modules'
   $nodejs_bin                        = '/usr/bin/node'
+  $npm_bin                           = '/usr/bin/npm'
   $environment                       = []
 
   $port                              = '8125'


### PR DESCRIPTION
As I noticed, we are assuming that npm path will always be the same. This assumption is something we don't do for nodejs binary ($nodejs_bin), for example. Beside that is also hardcoded, so I exported as a parameter that can be overwritten in case of being necessary.