### PR TITLE
Add back support for older Ubuntu releases

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -99,11 +99,19 @@ class statsd::params {
       $init_script    = 'puppet:///modules/statsd/statsd-init-rhel'
     }
     'Debian': {
-      $init_location  = '/lib/systemd/system/statsd.service'
-      $init_sysconfig = '/etc/default/statsd'
-      $init_mode      = '0644'
-      $init_provider  = 'systemd'
-      $init_script    = 'puppet:///modules/statsd/statsd-systemd'
+      if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemmajrelease, '16') < 0 {
+        $init_location  = '/etc/init/statsd.conf'
+        $init_sysconfig = '/etc/default/statsd'
+        $init_mode      = '0644'
+        $init_provider  = 'upstart'
+        $init_script    = 'puppet:///modules/statsd/statsd-upstart'
+      } else {
+        $init_location  = '/lib/systemd/system/statsd.service'
+        $init_sysconfig = '/etc/default/statsd'
+        $init_mode      = '0644'
+        $init_provider  = 'systemd'
+        $init_script    = 'puppet:///modules/statsd/statsd-systemd'
+      }
     }
     default: {
       fail('Unsupported OS Family')

--- a/spec/classes/statsd_spec.rb
+++ b/spec/classes/statsd_spec.rb
@@ -23,11 +23,13 @@ describe 'statsd', :type => :class do
       if osfamily == 'Debian'
         it { should contain_file('/etc/default/statsd') }
         it { should contain_file('/lib/systemd/system/statsd.service') }
+        it { should contain_service('statsd').with_provider('systemd') }
       end
 
       if osfamily == 'RedHat'
         it { should contain_file('/etc/sysconfig/statsd') }
         it { should contain_file('/etc/init.d/statsd') }
+        it { should contain_service('statsd').with_provider('redhat') }
       end
 
       describe 'disabling the management of backends' do
@@ -59,4 +61,29 @@ describe 'statsd', :type => :class do
       end
     end
   end
+
+  context 'using Ubuntu' do
+
+      describe 'when release version < 16' do
+      let(:facts) { {
+        :osfamily                  => 'Debian',
+        :operatingsystem           => 'Ubuntu',
+        :operatingsystemmajrelease => '14.04',
+      } }
+      it { should contain_file('/etc/init/statsd.conf') }
+      it { should contain_service('statsd').with_provider('upstart') }
+    end
+
+    describe 'when release version >= 16' do
+      let(:facts) { {
+        :osfamily                  => 'Debian',
+        :operatingsystem           => 'Ubuntu',
+        :operatingsystemmajrelease => '16.04',
+      } }
+      it { should contain_file('/lib/systemd/system/statsd.service') }
+      it { should contain_service('statsd').with_provider('systemd') }
+    end
+
+  end
+
 end


### PR DESCRIPTION
The changes in #46 broke all Ubuntu support outside of Xenial. This
change adds a check to select the correct service provider based on your
Ubuntu release version.