### PR TITLE
fix systemd unit file hardcoded stats.js and config paths

### DIFF
--- a/files/statsd-systemd
+++ b/files/statsd-systemd
@@ -4,8 +4,9 @@ Documentation=https://github.com/etsy/statsd/
 Wants=network.target
 
 [Service]
+EnvironmentFile=/etc/default/statsd
 Type=simple
-ExecStart=/usr/bin/nodejs /usr/local/lib/node_modules/statsd/stats.js /etc/statsd/localConfig.js
+ExecStart=/usr/bin/nodejs $STATSJS $STATSD_CONFIG
 Restart=on-failure
 RestartSec=10
 


### PR DESCRIPTION
These are parameterized for the init provider but hardcoded for systemd.  This broke on our Debian 8 hosts which use `/usr/lib/node_modules` rather than `/usr/local/lib/node_modules`.  

The paths were already correct in `/etc/default/statsd` which the module generates from `statsd-defaults.erb` so I just used it as a Systemd Environmentfile.    This is probably not the most portable fix (e.g. I don't think it will work for RHEL-, but these are currently not using systemd anyway) but it seems better than hardcoding?