### PR TITLE
Use of hard-coded password is a bad practice

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,6 @@
+:hierarchy:
+  - common
+:backends:
+  - yaml
+:yaml:
+:datadir: 'hieradata'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,6 +1,7 @@
-:hierarchy:
-  - common
-:backends:
-  - yaml
-:yaml:
-:datadir: 'hieradata'
+version: 5
+defaults:
+  datadir: 'hieradata'
+  data_hash: 'yaml_data'
+hierarchy:
+  - name: "common"
+    path: "common.yaml"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,0 +1,2 @@
+---
+influx_db_pwd: 'root'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,2 +1,2 @@
 ---
-influx_db_pwd: 'root'
+statsd::influxdb_password: 'root'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,7 +50,7 @@ class statsd::params {
   $influxdb_port                     = '8086'
   $influxdb_database                 = 'statsd'
   $influxdb_username                 = 'root'
-  $influxdb_password                 = hiera('influx_db_pwd')
+  $influxdb_password                 = statsd::influxdb_password
   $influxdb_version                  = '0.8'
   $influxdb_flush                    = true
   $influxdb_proxy                    = false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,7 +50,7 @@ class statsd::params {
   $influxdb_port                     = '8086'
   $influxdb_database                 = 'statsd'
   $influxdb_username                 = 'root'
-  $influxdb_password                 = 'root'
+  $influxdb_password                 = hiera('influx_db_pwd')
   $influxdb_version                  = '0.8'
   $influxdb_flush                    = true
   $influxdb_proxy                    = false


### PR DESCRIPTION
Greetings, 

I am a security researcher, who is looking for security smells in Puppet scripts. 
I noticed instances of hard-coded passwords, which are against the best practices 
recommended by Common Weakness Enumeration (CWE) [https://cwe.mitre.org/data/definitions/259.html] and also by other security practitioners.
I have added hiera support to mitigate this smell. Feedback is welcome. 

Here is where I noticed hard-coded passwords: https://github.com/justindowning/puppet-statsd/blob/master/manifests/params.pp